### PR TITLE
layoutの共通化

### DIFF
--- a/golang_todo_app/app/controllers/route_main.go
+++ b/golang_todo_app/app/controllers/route_main.go
@@ -1,16 +1,10 @@
 package controllers
 
 import (
-	"html/template"
-	"log"
 	"net/http"
 )
 
 // ハンドラー
 func top(w http.ResponseWriter, r *http.Request) {
-	t, err := template.ParseFiles("golang_todo_app/app/views/templates/top.html") //パッケージ名.関数名
-	if err != nil {
-		log.Fatalln(err) //エラーハンドリング
-	}
-	t.Execute(w, "Hello") //tの実行(args1: http.ResponseWriter, args2: データ[今回はnil])
+	generateHTML(w, "Hello", "layout", "top") //メソッド(args1: ResponseWriter, args2: data[明示的に渡している], args3: template[template1, template2])
 }

--- a/golang_todo_app/app/controllers/server.go
+++ b/golang_todo_app/app/controllers/server.go
@@ -1,9 +1,23 @@
 package controllers
 
 import (
+	"fmt"
 	"golang-todo-app/golang_todo_app/config"
+	"html/template"
 	"net/http"
 )
+
+// func 関数名(args1: ハンドラー関数の引数に設定したメソッド, args2: 型, args3: 可変調引数をstring型で設定)
+func generateHTML(w http.ResponseWriter, data interface{}, filenames ...string) {
+	//filenamesの中身のファイルを、スライス型の変数filesに格納していく処理
+	var files []string
+	for _, file := range filenames { //rangeで、引数として渡したfilenamesの中身を取り出す
+		files = append(files, fmt.Sprintf("golang_todo_app/app/views/templates/%s.html", file)) //取り出したものをfmt.Sprintfを使ってファイルパスに入れて、filesに格納する。(Mustの引数としてParseFilesを渡す事で、エラーの場合は「パニック」状態になる。)
+	}
+
+	templates := template.Must(template.ParseFiles(files...)) ////Must = templateをあらかじめキャッシュしておいて効率的に処理できる様にしている
+	templates.ExecuteTemplate(w, "layout", data)              //実行コマンド(args1: ResponseWriter, args2: 実行するテンプレート[明示的に渡している], args3: data)
+}
 
 func StartMainServer() error {
 	files := http.FileServer(http.Dir(config.Config.Static))

--- a/golang_todo_app/app/views/templates/layout.html
+++ b/golang_todo_app/app/views/templates/layout.html
@@ -1,0 +1,19 @@
+{{define "layout"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Document</title>
+  <link rel="stylesheet" href="/static/css/bootstrap.min.css">
+</head>
+<body>
+<div class="container text-center">
+  {{template "content" . }}
+</div>
+
+</body>
+<script src="/static/js/jquery-3.6.1.min.js"></script>
+<script src="/static/js/bootstrap.bundle.min.js"></script>
+</html>
+{{end}}

--- a/golang_todo_app/app/views/templates/top.html
+++ b/golang_todo_app/app/views/templates/top.html
@@ -1,18 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Document</title>
-  <link rel="stylesheet" href="/static/css/bootstrap.min.css">
-</head>
-<body>
-<div class="container text-center">
-  <h1>Top</h1>
-  {{.}}
-</div>
-
-</body>
-<script src="/static/js/jquery-3.6.1.min.js"></script>
-<script src="/static/js/bootstrap.bundle.min.js"></script>
-</html>
+{{define "content"}}
+<h1>Top</h1>
+{{.}}
+{{end}}


### PR DESCRIPTION
## 概要
 - layoutの共通化
   - layout.html
     - top.html のコードを移植して各ファイルで共通して使えるように実装
   - top.html
     - layout.html から呼び出せるように実装
   - server.go
     - generateHTML（filenamesの中身のファイルを、スライス型の変数filesに格納していく処理）を実装
   - route_main.go
     - server.goで作った関数 generateHTMLの実行