### PR TITLE
「ユーザーページの作成」と「アクセス制限」を設定

### DIFF
--- a/golang_todo_app/app/controllers/route_auth.go
+++ b/golang_todo_app/app/controllers/route_auth.go
@@ -11,7 +11,12 @@ import (
 // signupのハンドラー
 func signup(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "GET" { //r.Method とする事で、右辺で指定したリクエストのメソッドを取得する事ができる
-		generateHTML(w, nil, "layout", "public_navbar", "signup")
+		_, err := session(w, r)
+		if err != nil {
+			generateHTML(w, nil, "layout", "public_navbar", "signup")
+		} else {
+			http.Redirect(w, r, "/todos", 302)
+		}
 		//入力フォームの解析(r.Method == "POST")
 	} else if r.Method == "POST" { //Postの場合で行う処理 = 入力フォームで入力された値を元に新しいユーザーを作成する
 		err := r.ParseForm() //r.ParseFormとする事で、「入力フォームの解析」を行う。
@@ -34,7 +39,12 @@ func signup(w http.ResponseWriter, r *http.Request) {
 }
 
 func login(w http.ResponseWriter, r *http.Request) {
-	generateHTML(w, nil, "layout", "public_navbar", "login")
+	_, err := session(w, r)
+	if err != nil {
+		generateHTML(w, nil, "layout", "public_navbar", "login")
+	} else {
+		http.Redirect(w, r, "/todos", 302)
+	}
 }
 
 // loginのハンドラー

--- a/golang_todo_app/app/controllers/route_main.go
+++ b/golang_todo_app/app/controllers/route_main.go
@@ -4,7 +4,22 @@ import (
 	"net/http"
 )
 
-// ハンドラー
+// layout.htmlの表示をするハンドラー
 func top(w http.ResponseWriter, r *http.Request) {
-	generateHTML(w, "Hello", "layout", "public_navbar", "top") //メソッド(args1: ResponseWriter, args2: data[明示的に渡している], args3: template[template1, template2])
+	_, err := session(w, r) //sessionでcookieを取得する => そのcookieが「DBに存在するか」を判定する
+	if err != nil {         //エラー => ログインしていない ==> generateHTMLの処理に飛ばす
+		generateHTML(w, "Hello", "layout", "public_navbar", "top") //メソッド(args1: ResponseWriter, args2: data[明示的に渡している], args3: template[template1, template2])
+	} else {
+		http.Redirect(w, r, "/todos", 302) //ログインしている場合 => 「(/todos)のURLにアクセスする」という風にする
+	}
+}
+
+// index.htmlの表示をするハンドラー
+func index(w http.ResponseWriter, r *http.Request) {
+	_, err := session(w, r) //sessionを使って「ログインしているかどうか」の判定を取得する
+	if err != nil {         //エラーが有る場合は
+		http.Redirect(w, r, "/", 302) //ログインしていない = Topページにリダイレクトする
+	} else { //ただし、セッションが存在する場合は
+		generateHTML(w, nil, "layout", "private_navbar", "index") //indexを表示する
+	}
 }

--- a/golang_todo_app/app/views/templates/index.html
+++ b/golang_todo_app/app/views/templates/index.html
@@ -1,0 +1,3 @@
+{{ define "content" }}
+<h1>Index</h1>
+{{end}}

--- a/golang_todo_app/app/views/templates/private_navbar.html
+++ b/golang_todo_app/app/views/templates/private_navbar.html
@@ -1,0 +1,5 @@
+{{ define "navbar" }}
+<div class="container">
+    <a href="/logout">logout</a>
+</div>
+{{end}}


### PR DESCRIPTION
## 概要
 - 「ユーザーページの作成」と「アクセス制限」を設定
   - route_auth.go
     - ユーザーがログインした時にセッションを作成して、そのUUIDを変数cookieに保存する処理を追加
   - route_main.go
     - アクセス制限の根幹となる処理を追加
   - server.go
     - cookieを取得する関数を作成
     - パスの設定を追加（ /todos ）
   - index.html
     - ログインユーザーのみ見れる画面（ /todos ）に表示する文字列を記述
   - private_navbar.html
     - 他各所で設定した内容を（ /todos ）に反映